### PR TITLE
#14 Applied the correct return for the HttpStatusCode.InternalServerError

### DIFF
--- a/src/GeekLearning.RestKit.Core/ClientBase.cs
+++ b/src/GeekLearning.RestKit.Core/ClientBase.cs
@@ -131,7 +131,7 @@
                     case HttpStatusCode.Conflict:
                         return new ConflictApiException<TTarget>(message, result);
                     case HttpStatusCode.InternalServerError:
-                        return new ConflictApiException<TTarget>(message, result);
+                        return new InternalServerErrorApiException<TTarget>(message, result);
                     case HttpStatusCode.ServiceUnavailable:
                         return new ServiceUnavailableApiException<TTarget>(message, result);
                     default:


### PR DESCRIPTION
MapToException was returning the wrong ApiException for `HttpStatusCode.InternalServerError`. 

Applied the correct one.